### PR TITLE
Update initial conditions to have no infections

### DIFF
--- a/scripts/ensemble-sim.jl
+++ b/scripts/ensemble-sim.jl
@@ -17,7 +17,7 @@ model_types_vec = [("seasonal-infectivity-import", "tau-leaping")]
 N_vec = [500_000]
 nsims_vec = [1_000]
 init_states_prop_dict = [
-    Dict(:s_prop => 0.1, :e_prop => 0.01, :i_prop => 0.01, :r_prop => 0.88)
+    Dict(:s_prop => 0.1, :e_prop => 0.00, :i_prop => 0.00, :r_prop => 0.9)
 ]
 
 ensemble_state_p_vec = create_combinations_vec(

--- a/src/single-sim_setup.jl
+++ b/src/single-sim_setup.jl
@@ -7,8 +7,8 @@ using OutbreakDetection
 singlesim_states_p = StateParameters(;
     N = 500_000,
     s_prop = 0.1,
-    e_prop = 0.01,
-    i_prop = 0.01
+    e_prop = 0.00,
+    i_prop = 0.00
 )
 
 singlesim_time_p = SimTimeParameters(;


### PR DESCRIPTION
Remove large outbreak at start of simulations.
Importations are stochastic and will introduce an outbreak.